### PR TITLE
Fix error when an image is trying to be uploaded

### DIFF
--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -61,7 +61,7 @@
     <div class='col-2'>
       <%= f.field_container :image do %>
         <% if f.object.image? %>
-          <p><%= image_tag f.object.image, style: 'max-width: 100%; height: auto;' %></p>
+          <p><%= image_tag f.object.image.url, style: 'max-width: 100%; height: auto;' %></p>
         <% end %>
       <% end %>
     </div>

--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -26,7 +26,7 @@
       <% @slides.each do |slide|%>
         <tr id='<%= spree_dom_id slide %>' data-hook='admin_slides_index_rows'>
           <td class='no-border'><span class='handle'></span></td>
-          <td class='align-left'><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
+          <td class='align-left'><%= image_tag slide.slide_image.url, style: 'width: 120px; height: auto;' %></td>
           <td class='align-left'><%= link_to slide.name, object_url(slide) %></td>
           <td class='align-left'><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
           <td class='align-center'><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>


### PR DESCRIPTION
Quick Info
---
- An `ArgumentError` error was happening when it was trying to access the `/admin/slides route`.

Migrations? :-1:

What does this change?
----
- Fix the error occurred in `/admin/slides` route.

Why are you changing that?
----
- The way to access to the image route was incorrect, due to, this way it made reference to all the paperclip object instead of only the image URL. This adds a URL in order to only retrieve this value.

How did you accomplish this change?
----
- By adding the `.url` into de slide_image.

How do you manually test this?
----
- Go to the `/admin/slides` section and you will be able to access to this route.

Screenshots
----

### Before
![Screen Shot 2019-11-22 at 15 31 02](https://user-images.githubusercontent.com/13225845/69462391-79c04a80-0d3e-11ea-91de-0229dd79d29c.png)

### After
Now you're able to access 
![Screen Shot 2019-11-22 at 15 31 27](https://user-images.githubusercontent.com/13225845/69462424-9066a180-0d3e-11ea-9d5c-343c7326bc67.png)
the `/admin/slides` route.


